### PR TITLE
feat: 알림/채팅 로딩 스피너 → 스켈레톤 UI 교체 및 UI 개선

### DIFF
--- a/src/api/exercise/updateExerciseApi.ts
+++ b/src/api/exercise/updateExerciseApi.ts
@@ -12,6 +12,8 @@ export const updateExerciseApi = async (
     endTime: string;
     maxCapacity: number;
     notice: string;
+    allowMemberGuestsInvitation: boolean;
+    allowExternalGuests: boolean;
   },
 ) => {
   const { data } = await api.patch(`/api/exercises/${exerciseId}`, payload);

--- a/src/components/alert/AlertSkeleton.tsx
+++ b/src/components/alert/AlertSkeleton.tsx
@@ -1,0 +1,26 @@
+const AlertCardSkeleton = () => {
+  return (
+    <div className="flex w-[21.4375rem] flex-col gap-3 border-soft bg-white p-2">
+      <div className="flex w-full gap-3">
+        {/* 이미지 */}
+        <div className="h-10 w-10 flex-shrink-0 bg-gy-100 rounded animate-pulse" />
+        {/* 텍스트 영역 */}
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="h-[1rem] w-[6rem] bg-gy-100 rounded animate-pulse" />
+          <div className="h-[0.875rem] w-full bg-gy-100 rounded animate-pulse" />
+          <div className="h-[0.875rem] w-[70%] bg-gy-100 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const AlertSkeleton = ({ count = 6 }: { count?: number }) => {
+  return (
+    <div className="flex flex-col w-full items-center gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <AlertCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/chat/ChatDetailSkeleton.tsx
+++ b/src/components/chat/ChatDetailSkeleton.tsx
@@ -1,0 +1,40 @@
+// 채팅 내부 로딩 스켈레톤 UI
+
+const ChatBubbleSkeleton = ({ isMe }: { isMe: boolean }) => {
+  return (
+    <div className={`flex items-end gap-2 ${isMe ? "flex-row-reverse" : "flex-row"}`}>
+      {/* 프로필 이미지 (상대방만) */}
+      {!isMe && (
+        <div className="w-8 h-8 rounded-full bg-gy-100 animate-pulse flex-shrink-0" />
+      )}
+
+      <div className={`flex flex-col gap-1 ${isMe ? "items-end" : "items-start"}`}>
+        {/* 닉네임 (상대방만) */}
+        {!isMe && (
+          <div className="h-3 w-16 bg-gy-100 rounded animate-pulse" />
+        )}
+        {/* 말풍선 */}
+        <div
+          className={`h-9 rounded-2xl bg-gy-100 animate-pulse ${
+            isMe ? "w-40" : "w-52"
+          }`}
+        />
+      </div>
+
+      {/* 시간 */}
+      <div className="h-3 w-8 bg-gy-100 rounded animate-pulse self-end mb-1" />
+    </div>
+  );
+};
+
+export const ChatDetailSkeleton = () => {
+  const pattern = [false, true, false, false, true, true, false, true];
+
+  return (
+    <div className="flex flex-col gap-5 p-4">
+      {pattern.map((isMe, i) => (
+        <ChatBubbleSkeleton key={i} isMe={isMe} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/chat/ChatDetailTemplate.tsx
+++ b/src/components/chat/ChatDetailTemplate.tsx
@@ -34,7 +34,7 @@ import { uploadImage } from "../../api/image/imageUpload";
 import { useChatWsStore } from "../../store/useChatWsStore";
 import { resolveMemberId, resolveNickname } from "../../utils/auth";
 import useUserStore from "../../store/useUserStore";
-import { LoadingSpinner } from "../common/LoadingSpinner";
+import { ChatDetailSkeleton } from "./ChatDetailSkeleton";
 
 // 이모티콘
 import EmojiPicker from "../common/chat/EmojiPicker";
@@ -668,7 +668,7 @@ export const ChatDetailTemplate = ({
         )}
 
         {/* 상태 UI */}
-        {initLoading && <LoadingSpinner />}
+        {initLoading && <ChatDetailSkeleton />}
         {initError && (
           <CenterBox>
             <div className="flex flex-col items-center gap-3">

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -40,15 +40,17 @@ const ChatList = ({
 
   if (searchTerm !== "" && chatData.length == 0) {
     return (
-      // <div className="text-center text-gy-500 py-4">검색 결과가 없습니다.</div>
-      <EmptyState message="검색 결과가" />
+      <div className="flex flex-1 items-center justify-center min-h-[60dvh]">
+        <EmptyState message="검색 결과가" />
+      </div>
     );
   }
 
   if (chatData.length === 0) {
     return (
-      // <div className="text-center text-gy-500 py-4">채팅방이 없습니다.</div>
-      <EmptyState message={emptyMessageMap[tab]} />
+      <div className="flex flex-1 items-center justify-center min-h-[60dvh]">
+        <EmptyState message={emptyMessageMap[tab]} />
+      </div>
     );
   }
 

--- a/src/components/chat/GroupChatDetailTemplate.tsx
+++ b/src/components/chat/GroupChatDetailTemplate.tsx
@@ -30,7 +30,7 @@ import { uploadImage } from "../../api/image/imageUpload";
 // 유저 정보
 import useUserStore from "../../store/useUserStore";
 import { resolveMemberId, resolveNickname } from "../../utils/auth";
-import { LoadingSpinner } from "../common/LoadingSpinner";
+import { ChatDetailSkeleton } from "./ChatDetailSkeleton";
 
 // 이모티콘
 import EmojiPicker from "../common/chat/EmojiPicker";
@@ -519,7 +519,7 @@ export const GroupChatDetailTemplate: React.FC<
         className="flex-1 overflow-y-auto [&::-webkit-scrollbar]:hidden bg-gr-200"
       >
         {/* 상태 UI */}
-        {initLoading && <LoadingSpinner />}
+        {initLoading && <ChatDetailSkeleton />}
         {initError && (
           <CenterBox>
             <div className="flex flex-col items-center gap-3">

--- a/src/components/common/NewBadge.tsx
+++ b/src/components/common/NewBadge.tsx
@@ -1,8 +1,6 @@
 const NewBadge = () => (
-  <div className="flex shrink-0 items-center self-start rounded-[24px] bg-[var(--color-rd-500)] px-1">
-    <span className="body-sm-500 text-white">
-      NEW
-    </span>
+  <div className="flex shrink-0 items-center h-5 rounded-3xl bg-rd-500 px-1 ">
+    <span className="body-sm-500 text-white">NEW</span>
   </div>
 );
 

--- a/src/components/common/NewBadge.tsx
+++ b/src/components/common/NewBadge.tsx
@@ -1,0 +1,9 @@
+const NewBadge = () => (
+  <div className="flex shrink-0 items-center self-start rounded-[24px] bg-[var(--color-rd-500)] px-1">
+    <span className="body-sm-500 text-white">
+      NEW
+    </span>
+  </div>
+);
+
+export default NewBadge;

--- a/src/components/common/contentcard/alertTest/AlertInvite.tsx
+++ b/src/components/common/contentcard/alertTest/AlertInvite.tsx
@@ -1,4 +1,3 @@
-import NewBadge from "../../NewBadge";
 import RD500_XS from "../../Btn_Static/Text/RD500_XS";
 import GR600_XS from "../../Btn_Static/Text/GR600_XS";
 
@@ -6,7 +5,6 @@ interface AlertInviteProps {
   groupName: string;
   alertText: string;
   imageSrc: string;
-  isRead?: boolean;
   onAccept?: () => void;
   onReject?: () => void;
 }
@@ -15,7 +13,6 @@ const AlertInvite = ({
   groupName,
   alertText,
   imageSrc,
-  isRead = true,
   onAccept,
   onReject,
 }: AlertInviteProps) => {
@@ -34,7 +31,6 @@ const AlertInvite = ({
             {alertText}
           </span>
         </div>
-        {!isRead && <NewBadge />}
       </div>
 
       {/* 버튼 영역 */}

--- a/src/components/common/contentcard/alertTest/AlertInvite.tsx
+++ b/src/components/common/contentcard/alertTest/AlertInvite.tsx
@@ -1,3 +1,4 @@
+import NewBadge from "../../NewBadge";
 import RD500_XS from "../../Btn_Static/Text/RD500_XS";
 import GR600_XS from "../../Btn_Static/Text/GR600_XS";
 
@@ -5,6 +6,7 @@ interface AlertInviteProps {
   groupName: string;
   alertText: string;
   imageSrc: string;
+  isRead?: boolean;
   onAccept?: () => void;
   onReject?: () => void;
 }
@@ -13,6 +15,7 @@ const AlertInvite = ({
   groupName,
   alertText,
   imageSrc,
+  isRead = true,
   onAccept,
   onReject,
 }: AlertInviteProps) => {
@@ -25,12 +28,13 @@ const AlertInvite = ({
           alt="Group"
           className="h-10 w-10 border-hard object-cover"
         />
-        <div className="flex flex-col gap-1 text-left">
+        <div className="flex flex-1 flex-col gap-1 text-left">
           <span className="body-rg-400 text-black">{groupName}</span>
           <span className="line-clamp-2 w-full self-stretch overflow-hidden body-rg-500 text-black">
             {alertText}
           </span>
         </div>
+        {!isRead && <NewBadge />}
       </div>
 
       {/* 버튼 영역 */}

--- a/src/components/common/contentcard/alertTest/AlertTest1.tsx
+++ b/src/components/common/contentcard/alertTest/AlertTest1.tsx
@@ -25,7 +25,7 @@ const AlertTest1 = ({
       onClick={onClick}
     >
       {/* 상단 정보 영역 */}
-      <div className="flex w-full gap-3">
+      <div className="flex items-center w-full gap-3">
         <img
           src={imageSrc}
           alt="Group"

--- a/src/components/common/contentcard/alertTest/AlertTest1.tsx
+++ b/src/components/common/contentcard/alertTest/AlertTest1.tsx
@@ -1,9 +1,12 @@
+import NewBadge from "../../NewBadge";
+
 interface AlertTest1Props {
   groupName: string;
   alertText: string;
   alertType: string;
   descriptionText?: string;
   imageSrc: string;
+  isRead?: boolean;
   onClick?: () => void;
 }
 
@@ -13,6 +16,7 @@ const AlertTest1 = ({
   imageSrc,
   alertType,
   descriptionText,
+  isRead = true,
   onClick,
 }: AlertTest1Props) => {
   return (
@@ -27,15 +31,12 @@ const AlertTest1 = ({
           alt="Group"
           className="h-10 w-10 border-hard object-cover"
         />
-        <div className="flex flex-col gap-1 text-left">
+        <div className="flex flex-1 flex-col gap-1 text-left">
           <span className="body-rg-400 text-black">{groupName}</span>
           <div>
             <span className="line-clamp-2 w-full self-stretch overflow-hidden body-rg-500 text-black">
               {alertText}
             </span>
-            {/* <span className="line-clamp-2 w-full self-stretch overflow-hidden body-sm-500 text-[#9195a1]">
-              {descriptionText}
-            </span> */}
             {descriptionText && (
               <span className="line-clamp-2 w-full self-stretch overflow-hidden body-sm-500 text-[#9195a1]">
                 {descriptionText}
@@ -43,6 +44,7 @@ const AlertTest1 = ({
             )}
           </div>
         </div>
+        {!isRead && <NewBadge />}
       </div>
     </div>
   );

--- a/src/pages/alarm/AlertPage.tsx
+++ b/src/pages/alarm/AlertPage.tsx
@@ -87,7 +87,6 @@ export const AlertPage = () => {
       }
     }
 
-    // 객체로 오는 케이스도 대비
     const id = data?.invitationId;
     return typeof id === "number" ? id : Number(id ?? NaN);
   }
@@ -99,9 +98,6 @@ export const AlertPage = () => {
 
       // 현재 구현처럼 쿼리스트링로 전송
       await api.patch(`/api/notifications/${notificationId}?type=${type}`);
-
-      // 명세서대로 body로 보내야 한다면 위 1줄 대신 아래 사용
-      // await api.patch(`/api/notifications/${notificationId}`, { type });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["notifications"] });

--- a/src/pages/alarm/AlertPage.tsx
+++ b/src/pages/alarm/AlertPage.tsx
@@ -15,7 +15,7 @@ import { EmptyState } from "../../components/alert/EmptyState";
 import AlertTest1 from "../../components/common/contentcard/alertTest/AlertTest1";
 import type { AlertListResponse, ResponseAlertDto } from "../../types/alert";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { LoadingSpinner } from "../../components/common/LoadingSpinner";
+import { AlertSkeleton } from "../../components/alert/AlertSkeleton";
 import DefaultGroupImg from "@/assets/icons/defaultGroupImg.svg?url";
 
 const fetchNotifications = async (): Promise<ResponseAlertDto[]> => {
@@ -188,7 +188,7 @@ export const AlertPage = () => {
       {/* 알림 카드들 */}
       <div className="flex-1 flex flex-col items-center gap-4">
         {isLoading ? (
-          <LoadingSpinner />
+          <AlertSkeleton />
         ) : isError ? (
           <div className="text-center mt-10">에러 발생</div>
         ) : visibleNotifications.length === 0 ? (
@@ -203,7 +203,6 @@ export const AlertPage = () => {
                 groupName={alert.title}
                 alertText={alert.content}
                 imageSrc={alert.imgKey ?? DefaultGroupImg}
-                isRead={alert.isRead}
                 onAccept={() => handleAccept(alert.notificationId)}
                 onReject={() => handleReject(alert.notificationId)}
               />
@@ -216,21 +215,12 @@ export const AlertPage = () => {
                 alertType={alert.type}
                 isRead={alert.isRead}
                 descriptionText={getDescriptionText(alert.type)}
-                // onClick={
-                //   shouldMoveToDetail(alert.type)
-                //     ? () => handleDetail(alert.partyId, alert.data)
-                //     : undefined
-                // }
-                onClick={
-                  // 🌟CHANGE: 읽음 처리 후 상세 이동
-                  // 🌟SIMPLE: 읽음 처리만
-                  () => {
-                    markReadMutation.mutate(alert);
-                    if (shouldMoveToDetail(alert.type)) {
-                      handleDetail(alert.partyId, alert.data);
-                    }
+                onClick={() => {
+                  markReadMutation.mutate(alert);
+                  if (shouldMoveToDetail(alert.type)) {
+                    handleDetail(alert.partyId, alert.data);
                   }
-                }
+                }}
               />
             ),
           )

--- a/src/pages/alarm/AlertPage.tsx
+++ b/src/pages/alarm/AlertPage.tsx
@@ -203,6 +203,7 @@ export const AlertPage = () => {
                 groupName={alert.title}
                 alertText={alert.content}
                 imageSrc={alert.imgKey ?? DefaultGroupImg}
+                isRead={alert.isRead}
                 onAccept={() => handleAccept(alert.notificationId)}
                 onReject={() => handleReject(alert.notificationId)}
               />
@@ -213,6 +214,7 @@ export const AlertPage = () => {
                 alertText={alert.content}
                 imageSrc={alert.imgKey ?? DefaultGroupImg}
                 alertType={alert.type}
+                isRead={alert.isRead}
                 descriptionText={getDescriptionText(alert.type)}
                 // onClick={
                 //   shouldMoveToDetail(alert.type)

--- a/src/pages/group/CreateExercise.tsx
+++ b/src/pages/group/CreateExercise.tsx
@@ -260,20 +260,18 @@ export const CreateExercise = () => {
           />
         </div>
 
-        {!exerciseId && (
-          <div className="flex flex-col gap-5">
-            <TitleBtn
-              label="모임 멤버 게스트 초대 허용"
-              checked={!!allowGuestInvite}
-              onChange={setAllowGuestInvite}
-            />
-            <TitleBtn
-              label="외부 게스트 참여 허용"
-              checked={!!allowExternalGuest}
-              onChange={setAllowExternalGuest}
-            />
-          </div>
-        )}
+        <div className="flex flex-col gap-5">
+          <TitleBtn
+            label="모임 멤버 게스트 초대 허용"
+            checked={!!allowGuestInvite}
+            onChange={setAllowGuestInvite}
+          />
+          <TitleBtn
+            label="외부 게스트 참여 허용"
+            checked={!!allowExternalGuest}
+            onChange={setAllowExternalGuest}
+          />
+        </div>
 
         <TextField maxLength={45} value={notice} onChange={setNotice} />
       </div>


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

##  ✅ PR 체크리스트

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #460

## 👩🏻‍💻 작업 사항

### 스켈레톤 UI 교체
- `AlertPage` 로딩 시 스피너 → `AlertSkeleton` 컴포넌트로 교체
- 채팅 내부(`GroupChatDetailTemplate`, `ChatDetailTemplate`) 로딩 시 스피너 → `ChatDetailSkeleton` 컴포넌트로 교체

### 알림 UI 수정
- `AlertInvite`에서 `isRead` 파라미터 및 `NewBadge` 제거 (INVITE 타입은 뱃지 불필요)
- `NewBadge`의 `self-start` 제거 → 수직 중앙 정렬 수정

### 채팅 목록 빈 상태 UI
- 채팅 목록이 없을 때 `EmptyState` 이미지가 중앙에 오도록 수정

### 운동 수정 기능 개선
- 운동 수정하기에서도 모임 멤버 게스트 초대 허용 / 외부 게스트 참여 허용 토글 노출
- `updateExerciseApi` payload에 `allowMemberGuestsInvitation`, `allowExternalGuests` 필드 추가

## 📢 기타(공유 사항)
- `GET /api/exercises/{exerciseId}/for-edit` 응답값으로 게스트 허용 초기값 세팅됨
- 백엔드 `PATCH /api/exercises/{exerciseId}` 게스트 허용 필드 추가 반영 완료