### PR TITLE
fix: 알림 이미지 표시 및 모임 정보 수정 페이지 개선

### DIFF
--- a/src/pages/alarm/AlertPage.tsx
+++ b/src/pages/alarm/AlertPage.tsx
@@ -195,7 +195,7 @@ export const AlertPage = () => {
                 key={alert.notificationId}
                 groupName={alert.title}
                 alertText={alert.content}
-                imageSrc={alert.imgKey ?? DefaultGroupImg}
+                imageSrc={alert.imgUrl?.endsWith("/null") ? DefaultGroupImg : (alert.imgUrl ?? DefaultGroupImg)}
                 onAccept={() => handleAccept(alert.notificationId)}
                 onReject={() => handleReject(alert.notificationId)}
               />
@@ -204,7 +204,7 @@ export const AlertPage = () => {
                 key={alert.notificationId}
                 groupName={alert.title}
                 alertText={alert.content}
-                imageSrc={alert.imgKey ?? DefaultGroupImg}
+                imageSrc={alert.imgUrl?.endsWith("/null") ? DefaultGroupImg : (alert.imgUrl ?? DefaultGroupImg)}
                 alertType={alert.type}
                 isRead={alert.isRead}
                 descriptionText={getDescriptionText(alert.type)}

--- a/src/pages/group/AdminMenu/EditGroupInfoDefault.tsx
+++ b/src/pages/group/AdminMenu/EditGroupInfoDefault.tsx
@@ -46,9 +46,9 @@ export const EditGroupInfoDefault = () => {
   const isFormValid =
     selectedDays.length > 0 &&
     selectedTime !== "" &&
-    designatedText.trim() !== "" &&
-    joinFeeText.trim() !== "" &&
-    monthlyFeeText.trim() !== "";
+    (designatedChecked || designatedText.trim() !== "") &&
+    (joinFeeChecked || joinFeeText.trim() !== "") &&
+    (monthlyFeeChecked || monthlyFeeText.trim() !== "");
 
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -62,9 +62,23 @@ export const EditGroupInfoDefault = () => {
 
         setSelectedDays(data.activityDays);
         setSelectedTime(data.activityTime);
-        setDesignatedText(data.designatedCock);
-        setJoinFeeText(data.joinPrice?.toString() || "");
-        setMonthlyFeeText(data.price?.toString() || "");
+
+        const noDesignated = !data.designatedCock;
+        setDesignatedChecked(noDesignated);
+        setDesignatedText(noDesignated ? "" : data.designatedCock);
+
+        const noJoinFee = !data.joinPrice;
+        setJoinFeeChecked(noJoinFee);
+        setJoinFeeText(
+          noJoinFee ? "" : addWon(fmtKRW(data.joinPrice.toString())),
+        );
+
+        const noMonthlyFee = !data.price;
+        setMonthlyFeeChecked(noMonthlyFee);
+        setMonthlyFeeText(
+          noMonthlyFee ? "" : addWon(fmtKRW(data.price.toString())),
+        );
+
         setContentText(data.content || "");
         setKeywords(data.keywords || []);
         // if (data.partyImgUrl) setPhotos([data.partyImgUrl]);
@@ -202,7 +216,7 @@ export const EditGroupInfoDefault = () => {
   };
 
   return (
-    <div className="flex flex-col gap-8 mb-8">
+    <div className="flex flex-col gap-8 mb-33">
       <PageHeader title="모임 정보 수정" onBackClick={handleBackClick} />
       {isModalOpen && (
         <div className="fixed inset-0 flex justify-center items-center z-50">
@@ -364,7 +378,8 @@ export const EditGroupInfoDefault = () => {
             </TagBtn>
           ))}
         </div>
-
+      </div>
+      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[444px] bg-white px-4 z-10">
         <Grad_GR400_L
           label="수정하기"
           initialStatus={isFormValid ? "default" : "disabled"}

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -35,7 +35,7 @@ export type ResponseAlertDto = {
   content: string;
   type: AlertType;
   isRead: boolean;
-  imgKey: string;
+  imgUrl: string;
   data?: AlertData; //운동 id, 날짜
 };
 


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

##  ✅ PR 체크리스트

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #471

## 👩🏻‍💻 작업 사항

### 알림창 대표 이미지 미표시 버그 수정
- `ResponseAlertDto` 타입의 `imgKey` → `imgUrl` 필드명 수정 (API 응답과 불일치)
- `imgUrl`이 `.../null` 형태로 오는 경우 기본 이미지(`defaultGroupImg`)로 폴백 처리

### 모임 정보 수정 페이지 개선
- 기존 모임 정보 불러올 때 지정콕·가입비·회비의 `checked`(없음) 상태를 API 값 기반으로 초기화
- 가입비·회비를 포맷(원 단위)에 맞게 초기값 세팅
- `isFormValid` 조건을 "없음 체크됨 OR 값 입력됨" 방식으로 수정하여 수정하기 버튼 정상 활성화
- 수정하기 버튼을 하단 플로팅(`fixed`, `max-w-[444px]` 중앙 고정) 형태로 변경

## 📢 기타(공유 사항)
- 알림 이미지 `/null` 이슈는 백엔드에서 이미지 없는 경우 `imgUrl`을 `null`로 내려주면 근본적으로 해결됩니다.