### PR TITLE
feat: 채팅 안읽음 뱃지 및 웹소켓 연결 안정화

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       name="description"
       content="배드민턴 모임을 만들고, 추천 모임과 운동을 찾아보는 가장 스마트한 플랫폼"
     />
-    <link rel="canonical" href="https://www.cockple.store/" />
+    <link rel="canonical" href="https://www.cockple.site/" />
 
     <!-- 오픈 그래프 (공유) -->
     <meta property="og:site_name" content="콕플(Cockple)" />
@@ -20,7 +20,7 @@
       content="배드민턴 모임을 만들고, 추천 모임과 운동을 찾아보는 가장 스마트한 플랫폼"
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.cockple.store/" />
+    <meta property="og:url" content="https://www.cockple.site/" />
 
     <!-- 구조화 데이터 (SEO) -->
     <script type="application/ld+json">
@@ -29,8 +29,8 @@
         "@type": "Organization",
         "name": "콕플",
         "alternateName": "Cockple",
-        "url": "https://www.cockple.store/",
-        "logo": "https://www.cockple.store/icons/app_icon.png"
+        "url": "https://www.cockple.site/",
+        "logo": "https://www.cockple.site/icons/app_icon.png"
       }
     </script>
     <script type="application/ld+json">
@@ -39,7 +39,7 @@
         "@type": "WebSite",
         "name": "콕플",
         "alternateName": "Cockple",
-        "url": "https://www.cockple.store/"
+        "url": "https://www.cockple.site/"
       }
     </script>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.cockple.store/sitemap.xml
+Sitemap: https://www.cockple.site/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.cockple.store/</loc>
+    <loc>https://www.cockple.site/</loc>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,26 +1,3 @@
-// import axios from "axios";
-// const api = axios.create({
-//   baseURL: "https://cockple.store",
-// });
-
-// const TEMP_TOKEN = import.meta.env.VITE_APP_DEV_TOKEN;
-
-// api.interceptors.request.use(
-//   config => {
-//     if (TEMP_TOKEN) {
-//       config.headers.Authorization = `Bearer ${TEMP_TOKEN}`;
-//     }
-
-//     return config;
-//   },
-//   error => {
-//     return Promise.reject(error);
-//   },
-// );
-
-// export default api;
-
-//--------------------------리프레쉬 반영--------------------------
 import axios, { type InternalAxiosRequestConfig } from "axios";
 import useUserStore from "../store/useUserStore";
 

--- a/src/api/chat/rawWs.ts
+++ b/src/api/chat/rawWs.ts
@@ -101,6 +101,15 @@ export type UnsubscribeResponse =
       timestamp: string;
     };
 
+// --- 🌟내비바/채팅 탭 안읽음 뱃지용 (memberId 스코프, 방 구독과 무관하게 옴)
+export type UnreadStatusUpdate = {
+  type: "UNREAD_STATUS_UPDATE";
+  hasUnread: boolean;
+  hasPartyUnread: boolean;
+  hasDirectUnread: boolean;
+  timestamp: string;
+};
+
 // 새 브로드캐스트 포맷
 export type BroadcastMessage = {
   type: "SEND";
@@ -123,7 +132,8 @@ export type IncomingMessage =
   | SubscriptionResponse
   | UnsubscribeResponse
   | BroadcastMessage
-  | ChatRoomListUpdate; // 🌟 (채팅방 목록을 구독한 상대방에게 보내는 업데이트)
+  | ChatRoomListUpdate // 🌟 (채팅방 목록을 구독한 상대방에게 보내는 업데이트)
+  | UnreadStatusUpdate; // 🌟 내비바/채팅 탭 안읽음 뱃지
 
 //현재 구독 중인 방 목록을 전역으로 유지 (클라이언트 단의 '의도' 상태)
 // 서버는 Redis에 실제 구독을 보관/복원하므로 재연결시 재구독 전송은 불필요
@@ -145,12 +155,28 @@ export const addWsListener = (fn: MsgListener) => {
   };
 };
 
-type Handlers = {
-  onOpen?: (info?: ConnectResponse) => void;
-  onMessage?: (data: IncomingMessage) => void;
-  onError?: (ev: Event | Error) => void;
-  onClose?: (ev: CloseEvent) => void;
+// 연결 상태 리스너: 소켓을 누가 만들었는지와 무관하게 모든 구독자에게 통지
+type OpenListener = () => void;
+type CloseListener = (ev?: CloseEvent) => void;
+const openListeners = new Set<OpenListener>();
+const closeListeners = new Set<CloseListener>();
+
+export const addWsOpenListener = (fn: OpenListener) => {
+  openListeners.add(fn);
+  return () => {
+    openListeners.delete(fn);
+  };
 };
+
+export const addWsCloseListener = (fn: CloseListener) => {
+  closeListeners.add(fn);
+  return () => {
+    closeListeners.delete(fn);
+  };
+};
+
+// 동시 호출 시 소켓이 중복 생성되지 않도록 진행 중인 연결 시도를 공유
+let connectPromise: Promise<WebSocket | null> | null = null;
 
 const WS_ORIGIN = (
   import.meta.env.VITE_WS_ORIGIN ?? window.location.origin
@@ -214,10 +240,13 @@ const sendJSON = (msg: OutgoingMessage) => {
 };
 
 // --------- 공개 API ----------
-export const connectRawWs = async (
-  { memberId, origin }: { memberId: number; origin?: string },
-  handlers: Handlers = {},
-) => {
+export const connectRawWs = async ({
+  memberId,
+  origin,
+}: {
+  memberId: number;
+  origin?: string;
+}) => {
   // accessToken 없으면 연결 시도 안 함
   if (!hasToken()) {
     console.info("[WS] skipped: no accessToken");
@@ -231,72 +260,93 @@ export const connectRawWs = async (
     return ws;
   }
 
-  const base = buildSockUrl(origin);
-  const url = new URL(base);
-  url.searchParams.set("memberId", String(memberId));
-  url.searchParams.set("token", getToken()); // 서버가 헤더 대신 쿼리 파라미터로 읽는 형태라면 유지
+  // 동시 호출 시 소켓 중복 생성 방지 (SockJS dynamic import 대기 구간 레이스)
+  if (connectPromise) return connectPromise;
 
-  // SockJS dynamic import (초기 번들에서 제외)
-  const { default: SockJS } = await import("sockjs-client");
-  const sock = new SockJS(url.toString());
-  ws = sock as WebSocket;
+  connectPromise = (async () => {
+    const base = buildSockUrl(origin);
+    const url = new URL(base);
+    url.searchParams.set("memberId", String(memberId));
+    url.searchParams.set("token", getToken()); // 서버가 헤더 대신 쿼리 파라미터로 읽는 형태라면 유지
 
-  // readyState가 OPEN이 되면 onopen 호출
-  sock.onopen = () => {
-    reconnectAttempt = 0;
-    isManualClose = false; // 연결 성공 시 플래그 초기화
-    handlers.onOpen?.();
-  };
+    // SockJS dynamic import (초기 번들에서 제외)
+    const { default: SockJS } = await import("sockjs-client");
+    const sock = new SockJS(url.toString());
+    ws = sock as WebSocket;
 
-  sock.onmessage = (e: MessageEvent) => {
-    try {
-      const parsed: IncomingMessage = JSON.parse(e.data);
-      handlers.onMessage?.(parsed);
-
-      // 전역 리스너 브로드캐스트
-      listeners.forEach(fn => {
+    // readyState가 OPEN이 되면 onopen 호출 (등록된 모든 구독자에게 통지)
+    sock.onopen = () => {
+      reconnectAttempt = 0;
+      isManualClose = false; // 연결 성공 시 플래그 초기화
+      openListeners.forEach(fn => {
         try {
-          fn(parsed);
+          fn();
         } catch (err) {
-          console.warn("ws listener err", err);
+          console.warn("ws open listener err", err);
         }
       });
-    } catch {
-      console.warn("[SockJS] Non-JSON message:", e.data);
-    }
-  };
+    };
 
-  sock.onerror = (ev: Event) => {
-    handlers.onError?.(ev);
-  };
+    sock.onmessage = (e: MessageEvent) => {
+      try {
+        const parsed: IncomingMessage = JSON.parse(e.data);
+        console.log("[WS←]", parsed.type, parsed);
 
-  sock.onclose = (ev: CloseEvent) => {
-    console.warn("[WS close]", ev.code, ev.reason);
-    handlers.onClose?.(ev);
-    ws = null;
+        // 전역 리스너 브로드캐스트
+        listeners.forEach(fn => {
+          try {
+            fn(parsed);
+          } catch (err) {
+            console.warn("ws listener err", err);
+          }
+        });
+      } catch {
+        console.warn("[SockJS] Non-JSON message:", e.data);
+      }
+    };
 
-    // 🌟 수동으로 끊은 경우 재연결 시도 안 함
-    if (isManualClose) {
-      console.log("[WS] Manual disconnect. No reconnect.");
-      return;
-    }
+    sock.onerror = (ev: Event) => {
+      console.warn("[WS error]", ev);
+    };
 
-    // 토큰 없으면 재시도 안 함
-    if (!hasToken()) return;
+    sock.onclose = (ev: CloseEvent) => {
+      console.warn("[WS close]", ev.code, ev.reason);
+      closeListeners.forEach(fn => {
+        try {
+          fn(ev);
+        } catch (err) {
+          console.warn("ws close listener err", err);
+        }
+      });
+      ws = null;
+      connectPromise = null;
 
-    // 백오프 재연결
-    if (!reconnectTimer) {
-      const delay = Math.min(500 * 2 ** reconnectAttempt, 8000);
-      reconnectTimer = window.setTimeout(() => {
-        reconnectTimer = null;
-        reconnectAttempt++;
-        connectRawWs({ memberId, origin }, handlers);
-        //connectRawWs({ memberId, origin });
-      }, delay);
-    }
-  };
+      // 🌟 수동으로 끊은 경우 재연결 시도 안 함
+      if (isManualClose) {
+        console.log("[WS] Manual disconnect. No reconnect.");
+        return;
+      }
 
-  return ws!;
+      // 토큰 없으면 재시도 안 함
+      if (!hasToken()) return;
+
+      // 백오프 재연결
+      if (!reconnectTimer) {
+        const delay = Math.min(500 * 2 ** reconnectAttempt, 8000);
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          reconnectAttempt++;
+          connectRawWs({ memberId, origin });
+        }, delay);
+      }
+    };
+
+    return ws!;
+  })();
+
+  const result = await connectPromise;
+  connectPromise = null;
+  return result;
 };
 
 export const disconnectRawWs = () => {

--- a/src/api/chat/unreadStatus.ts
+++ b/src/api/chat/unreadStatus.ts
@@ -1,0 +1,10 @@
+// 안 읽은 채팅 존재 여부 (내비바 / 채팅 탭 뱃지용)
+// 서버가 memberId 스코프로 밀어주는 UNREAD_STATUS_UPDATE 웹소켓 메시지를
+// useUnreadStatusStore가 그대로 저장하고, 여기선 그 값을 읽기만 한다.
+import { useUnreadStatusStore, type UnreadStatus } from "../../store/useUnreadStatusStore";
+
+export type { UnreadStatus };
+
+export function useUnreadStatus(): UnreadStatus {
+  return useUnreadStatusStore(s => s.status);
+}

--- a/src/components/chat/ChatDetailTemplate.tsx
+++ b/src/components/chat/ChatDetailTemplate.tsx
@@ -23,6 +23,7 @@ import { useChatInfinite } from "../../hooks/useChatInfinite";
 import {
   addWsListener,
   subscribeRoom,
+  unsubscribeRoom,
   type IncomingMessage,
 } from "../../api/chat/rawWs";
 import { useRawWsConnect } from "../../hooks/useRawWsConnect";
@@ -127,7 +128,7 @@ export const ChatDetailTemplate = ({
     clearUnread(chatId); // 입장 즉시 0으로 (서버 PATCH는 useChatRead에서)
 
     return () => {
-      //unsubscribeRoom(chatId);
+      unsubscribeRoom(chatId);
       setActiveRoom(null); // 상세 퇴장
     };
   }, [chatId, setActiveRoom, clearUnread]);
@@ -246,8 +247,13 @@ export const ChatDetailTemplate = ({
   // 리스트에 그릴 최종 배열(초기 + 실시간/낙관적)
   const rendered = useMemo(() => {
     // messages가 오름차순이므로 live는 뒤에 붙인다.
-    // 정렬이 필요하면 여기에서 정렬.
-    return [...messages, ...liveMsgs];
+    // REST 재조회로 messages에 이미 들어온(확정 messageId) 항목은
+    // liveMsgs에서 제외해 중복 렌더를 막는다. 아직 낙관적(음수 id)인 건 유지.
+    const restIds = new Set(messages.map(m => m.messageId));
+    const filteredLive = liveMsgs.filter(
+      m => m.messageId < 0 || !restIds.has(m.messageId),
+    );
+    return [...messages, ...filteredLive];
   }, [messages, liveMsgs]);
 
   // ==== 전송: 텍스트 ====

--- a/src/components/chat/GroupChatDetailTemplate.tsx
+++ b/src/components/chat/GroupChatDetailTemplate.tsx
@@ -22,12 +22,13 @@ import { useChatInfinite } from "../../hooks/useChatInfinite";
 
 // WS 연결(원시 WebSocket 전용 훅)
 import { useRawWsConnect } from "../../hooks/useRawWsConnect";
-import { subscribeRoom } from "../../api/chat/rawWs";
+import { subscribeRoom, unsubscribeRoom } from "../../api/chat/rawWs";
 import type { ChatMessageResponse } from "../../types/chat";
 import { formatDateWithDay, formatEnLowerAmPm } from "../../utils/time";
 import { uploadImage } from "../../api/image/imageUpload";
 
 // 유저 정보
+import { useChatWsStore } from "../../store/useChatWsStore";
 import useUserStore from "../../store/useUserStore";
 import { resolveMemberId, resolveNickname } from "../../utils/auth";
 import { ChatDetailSkeleton } from "./ChatDetailSkeleton";
@@ -97,13 +98,21 @@ export const GroupChatDetailTemplate: React.FC<
   //   mode: "mock", // TODO: 백엔드 REST/WS 경로 확정 시 "rest" 또는 wsSendFn 적용
   // });
 
+  // 활성 방/읽음카운트 스토어 연동
+  const setActiveRoom = useChatWsStore(s => s.setActiveRoom);
+  const clearUnread = useChatWsStore(s => s.clearUnread);
+
   // 방 입장/퇴장: 단일 구독 유지
   useEffect(() => {
     subscribeRoom(roomId);
+    setActiveRoom(roomId); // 상세 입장
+    clearUnread(roomId);
+
     return () => {
-      //unsubscribeRoom(roomId);
+      unsubscribeRoom(roomId);
+      setActiveRoom(null); // 상세 퇴장
     };
-  }, [roomId]);
+  }, [roomId, setActiveRoom, clearUnread]);
 
   // ===== 로컬 상태 ====
   const [input, setInput] = useState("");
@@ -219,10 +228,15 @@ export const GroupChatDetailTemplate: React.FC<
   });
 
   // 리스트에 그릴 최종 배열(초기 + 실시간/낙관적)
-  const rendered = useMemo(
-    () => [...messages, ...liveMsgs],
-    [messages, liveMsgs],
-  );
+  // REST 재조회로 messages에 이미 들어온(확정 messageId) 항목은
+  // liveMsgs에서 제외해 중복 렌더를 막는다. 아직 낙관적(음수 id)인 건 유지.
+  const rendered = useMemo(() => {
+    const restIds = new Set(messages.map(m => m.messageId));
+    const filteredLive = liveMsgs.filter(
+      m => m.messageId < 0 || !restIds.has(m.messageId),
+    );
+    return [...messages, ...filteredLive];
+  }, [messages, liveMsgs]);
 
   // ==== 전송: 텍스트 ====
   const handleSendMessage = () => {

--- a/src/components/common/TabSelector.tsx
+++ b/src/components/common/TabSelector.tsx
@@ -14,6 +14,7 @@ interface TabSelectorProps<T extends string> {
   selected: T;
   onChange: (value: T) => void;
   type?: string;
+  dots?: Partial<Record<T, boolean>>;
 }
 
 const TabSelector = <T extends string>({
@@ -21,6 +22,7 @@ const TabSelector = <T extends string>({
   selected,
   onChange,
   type,
+  dots,
 }: TabSelectorProps<T>) => {
   return (
     <div className="w-full -ml-4 px-4 max-w-[444px] flex flex-col mb-4 fixed top-14 z-20 bg-white">
@@ -33,11 +35,17 @@ const TabSelector = <T extends string>({
         {options.map(option => (
           <TabBtn
             key={option.value}
-            children={option.label}
             onClick={() => onChange(option.value as T)}
             disabled={false}
             isSelected={selected === option.value}
-          />
+          >
+            <span className="relative inline-flex">
+              {option.label}
+              {dots?.[option.value as T] && (
+                <span className="absolute -top-0.5 -right-2 w-1.5 h-1.5 rounded-full bg-[#F62D2D]" />
+              )}
+            </span>
+          </TabBtn>
         ))}
       </div>
       <div className="h-[2px] bg-gray-100 relative -mt-[2px] z-0" />

--- a/src/components/common/system/navbar/NavItem.tsx
+++ b/src/components/common/system/navbar/NavItem.tsx
@@ -5,19 +5,31 @@ export interface NavItemProps {
   icon: string;
   active: boolean;
   onClick: () => void;
+  showDot?: boolean;
 }
 
-export const NavItem = ({ label, icon, active, onClick }: NavItemProps) => {
+export const NavItem = ({
+  label,
+  icon,
+  active,
+  onClick,
+  showDot = false,
+}: NavItemProps) => {
   return (
     <button
       className="flex flex-col items-center gap-2 py-2 w-16 border-hard active:bg-gray-100"
       onClick={onClick}
     >
-      <img
-        src={icon}
-        alt={`icon-${label}`}
-        className={clsx("w-6 h-6", active ? "-gr-700" : "")}
-      />
+      <span className="relative inline-flex">
+        <img
+          src={icon}
+          alt={`icon-${label}`}
+          className={clsx("w-6 h-6", active ? "-gr-700" : "")}
+        />
+        {showDot && (
+          <span className="absolute top-0 right-0 w-2 h-2 rounded-full bg-[#F62D2D]" />
+        )}
+      </span>
       <span className={clsx("body-sm-500", active ? "text-gr-700" : "")}>
         {label}
       </span>

--- a/src/components/common/system/navbar/Navbar.tsx
+++ b/src/components/common/system/navbar/Navbar.tsx
@@ -10,6 +10,8 @@ import MypageIcon from "@/assets/icons/mypage.svg";
 import MypageIconFilled from "@/assets/icons/mypage_filled.svg";
 import { NavItem } from "./NavItem";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useUnreadStatus } from "../../../../api/chat/unreadStatus";
+import { useChatWsStore } from "../../../../store/useChatWsStore";
 
 const NAV_ITEMS = [
   {
@@ -60,6 +62,12 @@ const NAV_ITEMS = [
 export const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const unreadStatus = useUnreadStatus();
+  // UNREAD_STATUS_UPDATE(서버 push) 외에, 이미 CHAT_ROOM_LIST_UPDATE로 쌓인
+  // 방별 unreadCount도 같이 봐서 한쪽이 안 와도 뱃지가 뜨도록 보강
+  const hasAnyRoomUnread = useChatWsStore(state =>
+    Object.values(state.meta).some(m => (m.unreadCount ?? 0) > 0),
+  );
 
   // const user = useUserStore(state => state.user);
 
@@ -82,6 +90,10 @@ export const Navbar = () => {
             icon={IconComponent}
             active={isActive}
             onClick={() => navigate(item.path)}
+            showDot={
+              item.path === "/chat" &&
+              (unreadStatus.hasUnread || hasAnyRoomUnread)
+            }
           />
         );
       })}

--- a/src/hooks/useRawWsConnect.ts
+++ b/src/hooks/useRawWsConnect.ts
@@ -10,6 +10,9 @@ import {
   type WsSendFile,
   type WsSendImage,
   addWsListener,
+  addWsOpenListener,
+  addWsCloseListener,
+  isRawWsOpen,
   type ChatRoomListUpdate,
 } from "../api/chat/rawWs";
 import { useChatWsStore } from "../store/useChatWsStore";
@@ -48,51 +51,24 @@ export const useRawWsConnect = (opts: {
       };
     }
 
-    connectRawWs(
-      { memberId: opts.memberId, origin: opts.origin },
-      {
-        onOpen: () => mounted.current && setOpen(true),
-        onClose: () => mounted.current && setOpen(false),
-        onMessage: msg => {
-          if (!mounted.current) return;
-          setLastMessage(msg);
+    connectRawWs({ memberId: opts.memberId, origin: opts.origin });
 
-          // WS → 전역 스토어 반영(목록 실시간 갱신)
-          if (msg.type === "SEND") {
-            applyInbound(msg); // 채팅방을 구독한 상대방에게 가는 브로드캐스트
-          }
+    // 연결 상태 구독: 소켓을 누가 만들었는지와 무관하게 항상 정확한 isOpen 반영
+    if (isRawWsOpen()) setOpen(true); // 이미 열려있으면 open 이벤트를 놓쳤을 수 있으니 즉시 반영
+    const offOpen = addWsOpenListener(() => mounted.current && setOpen(true));
+    const offClose = addWsCloseListener(() => mounted.current && setOpen(false));
 
-          // 채팅방 목록을 구독한 상대방에게 가는 브로드캐스트
-          if (msg.type === "CHAT_ROOM_LIST_UPDATE") {
-            const m = msg as ChatRoomListUpdate;
-            applyListUpdate({
-              chatRoomId: m.chatRoomId,
-              lastMessage: m.lastMessage?.content ?? null,
-              timestamp: m.lastMessage?.timestamp ?? null,
-              unreadCount: m.newUnreadCount ?? 0,
-            });
-          }
-
-          // 해제 ACK 로깅
-          if (
-            (msg.type === "UNSUBSCRIBE" || msg.type === "SUBSCRIBE") &&
-            "message" in msg &&
-            "chatRoomId" in msg
-          ) {
-            console.log(
-              `[WS] ${msg.type} ACK #${msg.chatRoomId}: ${msg.message}`,
-            );
-          }
-        },
-        onError: () => mounted.current && setOpen(false),
-      },
-    );
-
-    // 전역 리스너 구독 → 이미 열린 소켓이라도 무조건 수신 가능
+    // 전역 리스너 구독(한 곳에서만 처리 → 중복 반영 방지)
     const off = addWsListener(msg => {
       if (!mounted.current) return;
       setLastMessage(msg);
-      if (msg.type === "SEND") applyInbound(msg);
+
+      // WS → 전역 스토어 반영(목록 실시간 갱신)
+      if (msg.type === "SEND") {
+        applyInbound(msg); // 채팅방을 구독한 상대방에게 가는 브로드캐스트
+      }
+
+      // 채팅방 목록을 구독한 상대방에게 가는 브로드캐스트
       if (msg.type === "CHAT_ROOM_LIST_UPDATE") {
         const m = msg as ChatRoomListUpdate;
         applyListUpdate({
@@ -102,13 +78,24 @@ export const useRawWsConnect = (opts: {
           unreadCount: m.newUnreadCount ?? 0,
         });
       }
+
+      // 해제 ACK 로깅
+      if (
+        (msg.type === "UNSUBSCRIBE" || msg.type === "SUBSCRIBE") &&
+        "message" in msg &&
+        "chatRoomId" in msg
+      ) {
+        console.log(`[WS] ${msg.type} ACK #${msg.chatRoomId}: ${msg.message}`);
+      }
     });
 
     return () => {
       mounted.current = false;
       off(); // 🌟전역 리스너 해제
+      offOpen();
+      offClose();
     };
-  }, [opts.memberId, opts.origin, token, applyInbound]);
+  }, [opts.memberId, opts.origin, token, applyInbound, applyListUpdate]);
 
   return {
     isOpen,

--- a/src/pages/alarm/AlertPage.tsx
+++ b/src/pages/alarm/AlertPage.tsx
@@ -20,7 +20,7 @@ import DefaultGroupImg from "@/assets/icons/defaultGroupImg.svg?url";
 
 const fetchNotifications = async (): Promise<ResponseAlertDto[]> => {
   const response = await api.get<AlertListResponse>("/api/notifications");
-  return response.data.data;
+  return response.data.data.notifications;
 };
 
 export const AlertPage = () => {

--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -17,6 +17,7 @@ import {
   searchGroupChatRooms,
   searchPersonalChatRooms,
 } from "../../api/chat/chatList";
+import { useUnreadStatus } from "../../api/chat/unreadStatus";
 
 // ws
 import { useRawWsConnect } from "../../hooks/useRawWsConnect";
@@ -42,6 +43,9 @@ export const ChatPage = () => {
     { label: "모임채팅", value: "group" },
     { label: "개인채팅", value: "personal" },
   ];
+
+  // 안읽음 뱃지
+  const unreadStatus = useUnreadStatus();
 
   // 검색
   const [searchTerm, setSearchTerm] = useState("");
@@ -160,13 +164,13 @@ export const ChatPage = () => {
 
   const prevRoomsRef = useRef<number[]>([]);
 
-  // 현재 리스트에 보이는 방 id들
+  // 탭과 무관하게 두 탭 방 전부 구독 (탭 전환해도 실시간 갱신이 끊기지 않도록)
   const visibleRoomIds = useMemo(
-    () =>
-      (activeTab === "group" ? groupChatRooms : personalChatRooms).map(
-        c => c.chatRoomId,
-      ),
-    [activeTab, groupChatRooms, personalChatRooms],
+    () => [
+      ...groupChatRooms.map(c => c.chatRoomId),
+      ...personalChatRooms.map(c => c.chatRoomId),
+    ],
+    [groupChatRooms, personalChatRooms],
   );
 
   useEffect(() => {
@@ -240,6 +244,12 @@ export const ChatPage = () => {
     });
   }, [personalChatRooms, meta]);
 
+  // UNREAD_STATUS_UPDATE 외에, 이미 병합된 방별 unreadCount로도 보강
+  const hasPartyUnreadFromMeta = mergedGroup.some(r => (r.unreadCount ?? 0) > 0);
+  const hasDirectUnreadFromMeta = mergedPersonal.some(
+    r => (r.unreadCount ?? 0) > 0,
+  );
+
   return (
     <div className="flex flex-col w-full pt-14">
       <MainHeader />
@@ -249,6 +259,10 @@ export const ChatPage = () => {
           options={tabOptions}
           selected={activeTab}
           onChange={setActiveTab}
+          dots={{
+            group: unreadStatus.hasPartyUnread || hasPartyUnreadFromMeta,
+            personal: unreadStatus.hasDirectUnread || hasDirectUnreadFromMeta,
+          }}
         />
 
         <section className="flex flex-col w-full max-w-[23.4375rem] justify-center items-center gap-y-[1.25rem]">

--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -179,10 +179,6 @@ export const ChatPage = () => {
     const prev = new Set(prevRoomsRef.current);
     const next = new Set(visibleRoomIds);
 
-    //🌟 // 새로 보이게 된 방만 구독
-    // for (const id of next) if (!prev.has(id)) subscribeRoom(id);
-    // // 더 이상 보이지 않는 방만 해제
-    // for (const id of prev) if (!next.has(id)) unsubscribeRoom(id);
     const added: number[] = [];
     const removed: number[] = [];
 
@@ -193,13 +189,16 @@ export const ChatPage = () => {
     if (removed.length) unsubscribeChatList(removed);
 
     prevRoomsRef.current = visibleRoomIds;
-
-    return () => {
-      // 서버가 Redis에 구독을 보관하므로, 명시적 해제를 원하지 않는 한 유지합니다.
-      //prevRoomsRef.current.forEach(id => unsubscribeRoom(id));
-      prevRoomsRef.current = [];
-    };
   }, [isOpen, visibleRoomIds]);
+
+  // 채팅 목록 화면을 완전히 벗어날 때, 지금까지 구독해둔 방 전체를 한 번에 해제
+  useEffect(() => {
+    return () => {
+      if (prevRoomsRef.current.length) {
+        unsubscribeChatList(prevRoomsRef.current);
+      }
+    };
+  }, []);
 
   // 렌더 직전, 스토어 메타를 카드 데이터에 덮어쓰기
   const mergedGroup = useMemo(() => {

--- a/src/store/useUnreadStatusStore.ts
+++ b/src/store/useUnreadStatusStore.ts
@@ -1,0 +1,40 @@
+// 내비바 / 채팅 탭 안읽음 뱃지 상태.
+// 서버가 memberId 스코프로 UNREAD_STATUS_UPDATE 웹소켓 메시지를 보내주면
+// 그 값을 그대로 저장한다. REST 폴링/유추 없음 — 100% 서버 push.
+import { create } from "zustand";
+import { addWsListener } from "../api/chat/rawWs";
+
+export type UnreadStatus = {
+  hasUnread: boolean;
+  hasPartyUnread: boolean;
+  hasDirectUnread: boolean;
+};
+
+const initialStatus: UnreadStatus = {
+  hasUnread: false,
+  hasPartyUnread: false,
+  hasDirectUnread: false,
+};
+
+type State = {
+  status: UnreadStatus;
+};
+
+type Actions = {
+  setStatus: (status: UnreadStatus) => void;
+};
+
+export const useUnreadStatusStore = create<State & Actions>(set => ({
+  status: initialStatus,
+  setStatus: status => set({ status }),
+}));
+
+// 컴포넌트 마운트 여부와 무관하게 앱 전체에서 한 번만 구독
+addWsListener(msg => {
+  if (msg.type !== "UNREAD_STATUS_UPDATE") return;
+  useUnreadStatusStore.getState().setStatus({
+    hasUnread: msg.hasUnread,
+    hasPartyUnread: msg.hasPartyUnread,
+    hasDirectUnread: msg.hasDirectUnread,
+  });
+});

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -39,4 +39,12 @@ export type ResponseAlertDto = {
   data?: AlertData; //운동 id, 날짜
 };
 
-export type AlertListResponse = CommonResponse<ResponseAlertDto[]>;
+// 커서 기반 페이징 응답 구조
+export interface AlertListPage {
+  notifications: ResponseAlertDto[];
+  hasNext: boolean;
+  nextCursor: number | null;
+  totalElements: number;
+}
+
+export type AlertListResponse = CommonResponse<AlertListPage>;


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

##  ✅ PR 체크리스트

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #474

## 👩🏻‍💻 작업 사항

- 내비바 "채팅" 아이콘 및 채팅 탭(모임채팅/개인채팅)에 실시간 안읽음 뱃지 추가 (`UNREAD_STATUS_UPDATE` 웹소켓 메시지 기반, REST 폴링 없음)
- 웹소켓 연결 레이스 컨디션 수정: 여러 컴포넌트가 동시에 연결을 시도할 때 소켓이 중복 생성되거나 특정 컴포넌트의 연결 상태(`isOpen`)가 계속 `false`로 남던 문제 해결
- 채팅방 상세 진입/퇴장 시 `SUBSCRIBE`/`UNSUBSCRIBE`가 정상적으로 호출되도록 수정 (기존엔 퇴장 시 해제 로직이 주석 처리되어 있었음)
- 채팅 목록 화면을 벗어날 때 `UNSUBSCRIBE_CHAT_LIST`로 구독해둔 방 전체를 한 번에 해제하도록 추가
- REST 메시지 재조회와 웹소켓 낙관적 메시지가 함께 렌더되어 메시지가 중복 표시되던 문제 수정
- 알림 목록 API가 커서 기반 페이징 응답으로 변경된 것을 반영 (`notifications.filter is not a function` 런타임 에러 수정)

## 📢 기타(공유 사항)

- `UNREAD_STATUS_UPDATE`의 `hasPartyUnread`(모임채팅 안읽음)가 초반 테스트에서 계속 `false`로 오는 이슈가 있었는데, 방 구독 해제 로직을 정상화한 이후 정상적으로 `true`로 오는 것까지 확인했습니다. 혹시 배포 후에도 모임채팅 쪽 안읽음 표시가 이상하면 백엔드 쪽 안읽음 계산 로직 확인이 필요할 수 있습니다.