### PR TITLE
[FEAT] develop 브랜치도 미러 레포로 배포되도록 워크플로우 확장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: git push into another repo to deploy to vercel
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:
@@ -25,6 +25,6 @@ jobs:
           destination-repository-name: Cockple_FE
           user-email: ${{ secrets.EMAIL }}
           commit-message: ${{ github.event.commits[0].message }}
-          target-branch: main
+          target-branch: ${{ github.ref_name }}
       - name: Test get variable exported by push-to-another-repository
         run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [x] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

##  ✅ PR 체크리스트

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #481

## 👩🏻‍💻 작업 사항

배포용 GitHub Actions 워크플로우(`.github/workflows/deploy.yml`)를 `develop` 브랜치도 처리하도록 확장했습니다.

- `on.push.branches`에 `develop` 추가 → `develop` 푸시 시에도 미러 레포 배포 워크플로우 실행
- `target-branch`를 `main` 고정값에서 `${{ github.ref_name }}`로 변경 → 푸시된 브랜치 이름 그대로 미러 레포(`qowldud/Cockple_FE`)의 동일 이름 브랜치로 푸시 (main→main, develop→develop)

이로써 `develop`에 머지되면 Vercel이 `develop` 프리뷰 배포를 생성하게 됩니다. `main` 브랜치 동작에는 영향이 없습니다.

## 📢 기타(공유 사항)

배포 시 유의사항 / 후속 작업:

- **선행 작업**: 미러 레포(`qowldud/Cockple_FE`)에 `main` 기준으로 `develop` 브랜치를 미리 생성해야 첫 실행에서 `cpina/github-action-push-to-another-repository`가 대상 브랜치를 찾습니다.
- 머지 후 Vercel에서 `develop`(Preview) 전용 환경변수 분리 필요
  - `VITE_SERVER_API_URL`, `VITE_WS_ORIGIN` → staging 값(`https://staging.cockple.site`)으로 Preview 스코프 등록
  - 기존 변수는 Production 스코프로 축소
- 프리뷰 고정 URL 예상: `https://cockple-fe-git-develop-ji-youngs-projects.vercel.app`
- 위 도메인을 백엔드 CORS 허용 오리진 / Firebase 승인된 도메인 / Kakao Developers 플랫폼 도메인에 등록 필요
