### PR TITLE
fix: 빌드 실패 유발하는 미사용 선언 제거 (TS6133)

### DIFF
--- a/src/pages/group/MyGroupDetail/GameFinishedTab.tsx
+++ b/src/pages/group/MyGroupDetail/GameFinishedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from "react";
+import React, { useState, useMemo } from "react";
 import { useGetCompletedGames } from "../../../api/game/game";
 
 export interface PlayerInfo {

--- a/src/pages/group/MyGroupDetail/GameManagerPage.tsx
+++ b/src/pages/group/MyGroupDetail/GameManagerPage.tsx
@@ -1,25 +1,21 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { PageHeader } from "../../../components/common/system/header/PageHeader";
 import { Member, type MemberProps } from "../../../components/common/contentcard/Member";
-import { getExerciseDetail } from "../../../api/exercise/exercises";
 import { changeGameHost, useGetGameHostCandidates } from "../../../api/game/game";
-import useUserStore from "../../../store/useUserStore";
 import { useQueryClient } from "@tanstack/react-query";
 import DismissIcon from "../../../assets/icons/dismiss.svg?react";
 import Search from "../../../assets/icons/search.svg?react";
 import Grad_GR400_L from "../../../components/common/Btn_Static/Text/Grad_GR400_L";
-import GY800_S from "../../../components/common/Btn_Static/Text/GY800_S";
 
 export const GameManagerPage = () => {
   const navigate = useNavigate();
   const { exerciseId } = useParams<{ exerciseId: string }>();
   const exerciseIdNumber = Number(exerciseId);
-  const { user } = useUserStore();
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState("");
 
-  const { data, isLoading } = useGetGameHostCandidates(exerciseIdNumber);
+  const { data } = useGetGameHostCandidates(exerciseIdNumber);
   const totalCount = data?.totalCount || 0;
 
   const members: MemberProps[] = data?.participants.map(p => ({


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

##  ✅ PR 체크리스트

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

resolves #

## 👩🏻‍💻 작업 사항

Vercel 프로덕션 빌드(`npm run build` = `tsc -b && vite build`)가 `noUnusedLocals` 설정으로 인해 TS6133(미사용 선언) 에러로 실패하고 있어 이를 해결합니다.

**`GameFinishedTab.tsx`**
- 미사용 named import `useRef` 제거 (내부에서는 `React.useRef`를 사용 중)

**`GameManagerPage.tsx`**
- 미사용 import 제거: `useEffect`, `getExerciseDetail`, `GY800_S`, `useUserStore`
- 미사용 변수 제거: `const { user } = useUserStore()`
- `useGetGameHostCandidates` 구조분해에서 미사용 `isLoading` 제거

## 📢 기타(공유 사항)

- 로컬에서 `npx tsc -b --force` 통과(exit 0) 확인
- 동작 로직 변경 없음 (미사용 코드만 제거)
